### PR TITLE
chore: improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,11 @@ RUN \
 
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
-
-RUN npm i
-
 # RUN npm i --registry=https://registry.npm.taobao.org
 
 COPY . /usr/src/app
+
+RUN npm i
 
 EXPOSE 7001
 


### PR DESCRIPTION
因为会将当前目录整个拷贝到 /usr/src/app，所以前面的 package.json 单独拷贝一次没有必要。